### PR TITLE
Add a missing `address()` call.

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,6 +268,10 @@ class UTP extends events.EventEmitter {
   bind (...args) {
     this.socket.bind(...args)
   }
+  
+  address () {
+    this.socket.address()
+  }
 
   close (onclose) {
     if (onclose) this.once('close', onclose)


### PR DESCRIPTION
Address doesn't take any args so I didn't pass them through.