### PR TITLE
Use emscripten modularize option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-emcc -g -Wall -DPOSIX -fno-exceptions -O3 -fPIC -fno-rtti -Wno-sign-compare -fpermissive \
+emcc -g -Wall -DPOSIX -fno-exceptions -O3 -fPIC -fno-rtti -Wno-sign-compare -fpermissive -s MODULARIZE=1 \
   deps/libutp/utp_internal.cpp \
   deps/libutp/utp_utils.cpp \
   deps/libutp/utp_hash.cpp \

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const stream = require('stream')
 const events = require('events')
 const dgram = require('dgram')
-const em = require('./binding.js')
+const em = require('./binding.js')()
 
 const allocated = global._utp_allocated || []
 let ready = []


### PR DESCRIPTION
When using this module in a browser extension, the emscripten boilerplate does not specify a module export, which prevents this module from working. Using the `MODULARIZE=1` option to the emscripten compiler makes the generated code to always export the `Module` object, fixing the issue.